### PR TITLE
Optimize rebalancer and add loadtester script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,34 @@
+PROJECT_NAME := exxahub
+
+.PHONY: loadtest
+
 up:
 	docker-compose \
         -f docker-compose.yml \
-        -f docker-compose.local.yml \
+		-p ${PROJECT_NAME} \
         up --force-recreate --remove-orphans
 
 build:
 	docker-compose \
         -f docker-compose.yml \
-        -f docker-compose.local.yml \
+		-p ${PROJECT_NAME} \
         build        
 
 down:
 	docker-compose \
         -f docker-compose.yml \
-        -f docker-compose.local.yml \
+		-p ${PROJECT_NAME} \
         down --remove-orphans
 
 destroy:
 	docker-compose \
         -f docker-compose.yml \
-        -f docker-compose.local.yml \
-        down -v --remove-orphans		
+		-p ${PROJECT_NAME} \
+        down -v --remove-orphans	
+
+loadtest:
+	docker-compose \
+		-f docker-compose.yml \
+		-f docker-compose.loadtest.yml \
+		-p ${PROJECT_NAME} \
+		run --rm loadtester run /app/test.js

--- a/docker-compose.loadtest.yml
+++ b/docker-compose.loadtest.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  loadtester:
+    build: loadtest/
+    container_name: loadtester
+    networks:
+      - exxa_network
+    volumes:
+      - ./loadtest/test.js:/app/test.js
+    working_dir: /app

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,7 +1,0 @@
-version: '3.8'
-
-services:
-  exxa_backtester:
-    volumes:
-      - .:/usr/src/app
-    command: ["bun", "--watch", "run", "./src/api/index.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
 version: '3.8'
 
 services:
-  exxa_backtester:
+  backtester:
     build: .
-    container_name: exxa_backtester
+    container_name: backtester
     ports:
       - "3000:3000"
     networks:
       - exxa_network
     env_file:
       - .env
-    command: ["bun", "run", "./src/api/index.ts"]
+    volumes:
+      - .:/usr/src/app
+    command: ["bun", "--watch", "run", "./src/api/index.ts"]
 
   database:
     image: 'postgres:16.4-alpine3.20'
-    container_name: exxa_backtester_db
+    container_name: backtester_db
     ports:
       - 5432:5432
     networks:

--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -1,0 +1,8 @@
+# Start from the official k6 image
+FROM grafana/k6:latest
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the test script into the container
+COPY test.js /app/test.js

--- a/loadtest/run.sh
+++ b/loadtest/run.sh
@@ -1,0 +1,3 @@
+docker build -t k6-load-test -f Dockerfile .
+
+docker run --rm k6-load-test

--- a/loadtest/test.js
+++ b/loadtest/test.js
@@ -1,0 +1,101 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Configurations
+export const options = {
+  stages: [
+    { duration: '5s', target: 1 }
+    // { duration: '30s', target: 10 }, // Ramp-up to 10 users over 30 seconds
+    // { duration: '1m', target: 10 },  // Stay at 10 users for 1 minute
+    // { duration: '30s', target: 0 },  // Ramp-down to 0 users over 30 seconds
+  ],
+};
+
+const payload = JSON.stringify({
+    "starting_balance": 10000,
+    "start_date": "2024-01-02",
+    "end_date": "2026-01-02",
+    "trading_bot": {
+      "name": "New Trading Bot",
+      "rebalance": "daily",
+      "id": "new",
+      "node_type": "root",
+      "description": "",
+      "children": [
+          {
+              "id": "5e4aa7c6-81ef-4b68-bf97-8f9913a1cd31",
+              "node_type": "wt-cash-equal",
+              "children": [
+                  {
+                      "weight": {
+                          "num": 100,
+                          "den": 100
+                      },
+                      "id": "5811db0f-357b-4104-94ea-a7501f4b71df",
+                      "node_type": "group",
+                      "name": "10d RSI HYD > 10d RSI IYZ",
+                      "children": [
+                          {
+                              "node_type": "wt-cash-equal",
+                              "id": "6ef32806-b2fe-4a49-9f39-838f576e40e6",
+                              "children": [
+                                  {
+                                      "id": "cdbe8337-e418-4f85-bc39-69f1842fd1d9",
+                                      "node_type": "if-then-else",
+                                      "condition_type": "allOf",
+                                      "conditions": [
+                                          {
+                                              "node_type": "condition",
+                                              "lhs_fn": "relative-strength-index",
+                                              "lhs_fn_params": {
+                                                  "window": 10
+                                              },
+                                              "lhs_val": "HYD",
+                                              "rhs_fn": "relative-strength-index",
+                                              "rhs_fn_params": {
+                                                  "window": 10
+                                              },
+                                              "rhs_val": "IYZ",
+                                              "comparator": "gt"
+                                          }
+                                      ],
+                                      "then_children": [
+                                          {
+                                              "ticker": "TQQQ",
+                                              "exchange": "XNAS",
+                                              "name": "ProShares UltraPro QQQ",
+                                              "id": "8b6f212c-e237-4764-9f83-ed0293a35059",
+                                              "node_type": "asset"
+                                          }
+                                      ],
+                                      "else_children": [
+                                          {
+                                              "ticker": "KMLM",
+                                              "exchange": "ARCX",
+                                              "name": "ProShares Short QQQ",
+                                              "id": "72463f12-d3da-44f7-86aa-9f83dd176ae1",
+                                              "node_type": "asset"
+                                          }
+                                      ]
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              ]
+          }
+      ]
+  }
+})
+
+const headers = { 'Content-Type': 'application/json' };
+
+export default function () {
+  const res = http.post('http://backtester:3000/api/v1/backtests', payload, { headers });
+
+  // Validate the response
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response time < 200ms': (r) => r.timings.duration < 200,
+  });
+}

--- a/src/services/Backtester.ts
+++ b/src/services/Backtester.ts
@@ -7,12 +7,19 @@ import { Interpreter } from "./Interpreter";
 import { Parser } from "./Parser"
 import type { BacktestConfig } from "../api/schemas/CreateBacktestRequest";
 
+export type AllocationResult = { 
+    date: string,
+    tickers: {
+        [key: string]: number | null
+    }
+}
+
 type BacktestResults = {
     date_from?: string,
     date_to?: string,
     starting_balance?: number
     ending_balance?: number,
-    allocation_history?: { [key: string]: string | number | null }[]
+    allocation_history?: AllocationResult[]
     balance_history?: number[]
     ticker_start_dates?: { [key: string]: string }
 }
@@ -26,7 +33,7 @@ export class Backtester {
     private defaultBacktestStartDate: string
     private defaultBacktestEndDate: string
     
-    private allocationResults: { [key: string]: string | number | null }[] = []
+    private allocationResults: AllocationResult[] = []
     private backtestResults: BacktestResults = {}
 
     private tickerStartDates: Record<string, string> = {}
@@ -77,10 +84,10 @@ export class Backtester {
             
             this.allocationResults.push({
                 date: currentDate.format('YYYY-MM-DD'),
-                ...allocations
+                tickers: allocations
             })
 
-            rebalancer.rebalance(currentDate, allocations)
+            rebalancer.rebalance(currentDate.format('YYYY-MM-DD'), allocations)
 
             if (currentDate.isSame(toDate)) {
                 break

--- a/src/services/Rebalancer.ts
+++ b/src/services/Rebalancer.ts
@@ -59,7 +59,7 @@ export class Rebalancer {
         this.balanceHistory.push(this.portfolioValue)
     }
 
-    rebalance(date: Dayjs, newAllocations: Allocations): void {
+    rebalance(date: string, newAllocations: Allocations): void {
         // update portfolio value based on current day's close
         this.updatePortfolioValue(date)
         
@@ -130,7 +130,7 @@ export class Rebalancer {
         return newHoldings
     }
 
-    private updatePortfolioValue(date: Dayjs): void {
+    private updatePortfolioValue(date: string): void {
         if (Object.keys(this.currentHoldings).length === 0) {
             this.setPortfolioValue(INITIAL_PORTFOLIO_VALUE)
             return 
@@ -145,7 +145,7 @@ export class Rebalancer {
         this.setPortfolioValue(newValue)
     }
 
-    private getTickerPriceOnDate(ticker: string, date: Dayjs): number {
+    private getTickerPriceOnDate(ticker: string, date: string): number {
         const bar = this.ohlcCache.getBarForDate(ticker, date)
         if (!bar) {
             throw new Error('No bar available to update holdings')


### PR DESCRIPTION
Refactored `OhlcCache.getBarForDate()` to use a lookup by key on a Map, rather than searching through an array on each iteration, which should help performance in the rebalancer. 

Also added a new `make loadtest` command that spins up a container and runs a loadtest with k6 so we can get a baseline for the backtest API performance. (This will still hammer the market data source APIs so be careful running this for now. It will be way more useful once we can store OHLC data in a local datastore)